### PR TITLE
Fix the transition from NebulousLabs to SkynetLabs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Skynet Go SDK
 
-[![Go](https://img.shields.io/github/go-mod/go-version/NebulousLabs/go-skynet)](https://github.com/NebulousLabs/go-skynet)
-[![Build Status](https://img.shields.io/github/workflow/status/NebulousLabs/go-skynet/PR)](https://github.com/NebulousLabs/go-skynet/actions)
-[![Contributors](https://img.shields.io/github/contributors/NebulousLabs/go-skynet)](https://github.com/NebulousLabs/go-skynet/graphs/contributors)
-[![License](https://img.shields.io/github/license/NebulousLabs/go-skynet)](https://github.com/NebulousLabs/go-skynet)
+[![Go](https://img.shields.io/github/go-mod/go-version/SkynetLabs/go-skynet)](https://github.com/SkynetLabs/go-skynet)
+[![Build Status](https://img.shields.io/github/workflow/status/SkynetLabs/go-skynet/PR)](https://github.com/SkynetLabs/go-skynet/actions)
+[![Contributors](https://img.shields.io/github/contributors/SkynetLabs/go-skynet)](https://github.com/SkynetLabs/go-skynet/graphs/contributors)
+[![License](https://img.shields.io/github/license/SkynetLabs/go-skynet)](https://github.com/SkynetLabs/go-skynet)
 
 An SDK for integrating Skynet into Go applications.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/SkynetLabs/go-skynet/v2
 go 1.13
 
 require (
-	github.com/SkynetLabs/go-skynet/v2 v2.0.1
 	gitlab.com/NebulousLabs/errors v0.0.0-20171229012116-7ead97ef90b8
 	gopkg.in/h2non/gock.v1 v1.0.15
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/SkynetLabs/go-skynet/v2 v2.0.1 h1:c5x/onhWwap9p9QgcGZtep580vUYdcIdCgAHueyksyM=
-github.com/SkynetLabs/go-skynet/v2 v2.0.1/go.mod h1:uhGD1M7Qe1nXsnqRD90B5CJVgjqSqwJUmDosgAn4CdQ=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=

--- a/tests/download_integration_test.go
+++ b/tests/download_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	skynet "github.com/NebulousLabs/go-skynet/v2"
+	skynet "github.com/SkynetLabs/go-skynet/v2"
 	"gopkg.in/h2non/gock.v1"
 )
 

--- a/tests/skykeys_integration_test.go
+++ b/tests/skykeys_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	skynet "github.com/NebulousLabs/go-skynet/v2"
+	skynet "github.com/SkynetLabs/go-skynet/v2"
 	"gopkg.in/h2non/gock.v1"
 )
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 
-	skynet "github.com/NebulousLabs/go-skynet/v2"
+	skynet "github.com/SkynetLabs/go-skynet/v2"
 	"gopkg.in/h2non/gock.v1"
 )
 

--- a/tests/upload_integration_test.go
+++ b/tests/upload_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	skynet "github.com/NebulousLabs/go-skynet/v2"
+	skynet "github.com/SkynetLabs/go-skynet/v2"
 	"gopkg.in/h2non/gock.v1"
 )
 


### PR DESCRIPTION
In order to rename a package to use our new github org's path, we need to fix a bunch of paths throughout the project.
This PR does that.

Closes #4