### PR TITLE
[SKY-55] Skynet API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,38 @@
 # Changelog
 
-## [2.0.1]
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Types of changes:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Removed` for now removed features.
+- `Deprecated` for soon-to-be removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
+## [Unreleased]
+
+### Added
+
+- Add `SkynetAPIKey` option.
+
+### Fixed
+
+- Ensure custom portal URLs start with `https://`.
+
+## [2.0.2]
 
 ### Changed
+
+- Made transition from NebulousLabs to SkynetLabs
+
+## [2.0.1]
+
+### Fixed
 
 - Fixed single-file directory uploads being uploaded as files instead of
   directories.
@@ -17,6 +47,9 @@
   API calls, to be applied to all API calls.
 - The `defaultPortalUrl` string has been renamed to `defaultSkynetPortalUrl` and
   `defaultPortalUrl` is now a function.
+
+### Fixed
+
 - Fix a bug where the Content-Type was not set correctly.
 
 ## [1.1.0]
@@ -30,7 +63,7 @@
 - API authentication
 - Encryption
 
-### Changed
+### Fixed
 
 - Some upload bugs were fixed.
 

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"gitlab.com/NebulousLabs/errors"
 )
@@ -39,7 +40,7 @@ func NewCustom(portalURL string, customOptions Options) SkynetClient {
 		portalURL = DefaultPortalURL()
 	}
 	return SkynetClient{
-		PortalURL: portalURL,
+		PortalURL: ensurePrefix(strings.TrimPrefix(portalURL, "http://"), "https://"),
 		Options:   customOptions,
 	}
 }

--- a/client.go
+++ b/client.go
@@ -59,6 +59,9 @@ func (sc *SkynetClient) executeRequest(config requestOptions) (*http.Response, e
 	if config.APIKey != "" {
 		opts.APIKey = config.APIKey
 	}
+	if config.SkynetAPIKey != "" {
+		opts.SkynetAPIKey = config.SkynetAPIKey
+	}
 	if config.CustomUserAgent != "" {
 		opts.CustomUserAgent = config.CustomUserAgent
 	}
@@ -76,6 +79,9 @@ func (sc *SkynetClient) executeRequest(config requestOptions) (*http.Response, e
 	}
 	if opts.APIKey != "" {
 		req.SetBasicAuth("", opts.APIKey)
+	}
+	if opts.SkynetAPIKey != "" {
+		req.Header.Set("Skynet-Api-Key", opts.SkynetAPIKey)
 	}
 	if opts.CustomUserAgent != "" {
 		req.Header.Set("User-Agent", opts.CustomUserAgent)

--- a/tests/upload_integration_test.go
+++ b/tests/upload_integration_test.go
@@ -93,6 +93,35 @@ func TestUploadFileWithAPIKey(t *testing.T) {
 	}
 }
 
+// TestUploadFileWithSkynetAPIKey tests uploading a single file with Skynet authentication.
+func TestUploadFileWithSkynetAPIKey(t *testing.T) {
+	defer gock.Off() // Flush pending mocks after test execution
+
+	// Test uploading a file with a Skynet API key set.
+
+	// Upload file request.
+	opts := skynet.DefaultUploadOptions
+	opts.SkynetAPIKey = "foobar"
+	gock.New(skynet.DefaultPortalURL()).
+		Post(opts.EndpointPath).
+		MatchHeader("Skynet-API-Key", "foobar").
+		Reply(200).
+		JSON(map[string]string{"skylink": skylink})
+
+	sialink2, err := client.UploadFile(srcFile, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sialink2 != sialink {
+		t.Fatalf("expected sialink %v, got %v", sialink, sialink2)
+	}
+
+	// Verify we don't have pending mocks.
+	if !gock.IsDone() {
+		t.Fatal("test finished with pending mocks")
+	}
+}
+
 // TestUploadCustomUserAgent tests uploading a single file with a custom user
 // agent.
 func TestUploadCustomUserAgent(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -29,6 +29,9 @@ type (
 
 		// APIKey is the API password to use for authentication.
 		APIKey string
+		// SkynetAPIKey is the authentication API key to use for a Skynet portal
+		// (sets the "Skynet-Api-Key" header).
+		SkynetAPIKey string
 		// CustomUserAgent is the custom user agent to use.
 		CustomUserAgent string
 
@@ -57,6 +60,7 @@ func DefaultOptions(endpointPath string) Options {
 		EndpointPath: endpointPath,
 
 		APIKey:          "",
+		SkynetAPIKey:    "",
 		CustomUserAgent: "",
 	}
 }
@@ -72,6 +76,8 @@ func DefaultPortalURL() string {
 
 // ensurePrefix checks if `str` starts with `prefix` and adds it if that's not
 // the case.
+//
+// NOTE: Taken from `skyd` - see that project for tests.
 func ensurePrefix(str, prefix string) string {
 	if strings.HasPrefix(str, prefix) {
 		return str

--- a/utils.go
+++ b/utils.go
@@ -70,6 +70,15 @@ func DefaultPortalURL() string {
 	return DefaultSkynetPortalURL
 }
 
+// ensurePrefix checks if `str` starts with `prefix` and adds it if that's not
+// the case.
+func ensurePrefix(str, prefix string) string {
+	if strings.HasPrefix(str, prefix) {
+		return str
+	}
+	return prefix + str
+}
+
 // makeResponseError makes an error given an error response.
 func makeResponseError(resp *http.Response) error {
 	body := &bytes.Buffer{}


### PR DESCRIPTION
# PULL REQUEST

## Overview

- [Ensure custom portal URLs start with https://](https://github.com/SkynetLabs/go-skynet/commit/28d97ddbbe11ef13b9ddf9b8cc9ca3d17d2bd82d)
- [Add SkynetAPIKey option](https://github.com/SkynetLabs/go-skynet/commit/ce063c96333c4442b62f4f38eb8855bb0d7a4d6f)

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created
